### PR TITLE
[Feature]: Icon corner radius customization

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -87,7 +87,7 @@ Object.entries(shortNames).forEach(([short, full]) => {
 });
 
 router.get("/icons", async (req: Request, res: Response) => {
-    const { i, perline } = req.query;
+    const { i, perline, radius } = req.query;
     const iconsDir = path.join(__dirname, "../../icons");
     if (i && typeof i === "string") {
         const iconsList = i.split(",");


### PR DESCRIPTION
### 🔗 Linked issue


### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

This PR adds a `radius` query parameter, allowing users to customize the corner radius of icons. The radius value is applied to the rx attribute of the <rect /> element. If the radius is not provided, it defaults to 25. The value is validated to stay within a specified range, clamping any out-of-bound values to the minimum or maximum limits.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] I confirm that I have read and agree to abide by the Code of Conduct.