### PR TITLE
fix(icons): fix spring icon name mapping

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -80,7 +80,6 @@ const shortNames: Record<string, string> = {
     "sclearn": "scikitlearn",
     "sdl": "simpledirectmedialayer",
     "solid": "solidjs",
-    "spring": "springboot",
     "so": "stackoverflow",
     "truenas": "truenascore",
     "tailwind": "tailwindcss",


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🆕 Icon Added (new icon introduced)
- [ ] 🔧 Icon Update (updated an existing icon)
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug Fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New Feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking Change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed `Spring` icon name mapping

### 🔗 Linked issue

- Closes #346 

### 📝 Checklist

- [x] I created the icon(s) using one of the provided icon [templates](../tree/main/.github/ICON_TEMPLATES).
- [x] I have added the icon to the correct directory (`/icons`).
- [x] I have ensured the icon name follows the naming convention (e.g., `iconname.svg`).
- [x] I have linked an issue or discussion.
- [x] I acknowledge that I have read and agree to follow the `Code of Conduct`.